### PR TITLE
Add logic.jl and its respective Base.Test tests.

### DIFF
--- a/agents.jl
+++ b/agents.jl
@@ -26,8 +26,6 @@ export AgentProgram,
         test_agent, compare_agents;
 
 
-abstract AgentProgram;      #declare AgentProgram as a supertype for AgentProgram implementations
-
 #=
 
     Define a global execute() function to be implemented for each respective

--- a/aimajulia.jl
+++ b/aimajulia.jl
@@ -10,6 +10,8 @@ typealias Action String;
 
 typealias Percept Tuple{Any, Any};
 
+include("logic.jl");
+
 include("agents.jl");
 
 include("search.jl");

--- a/logic.jl
+++ b/logic.jl
@@ -1,0 +1,147 @@
+
+import Base: hash, ==, show,
+            <, <=, >, >=,
+            -, +, *, ^, /, \, %,
+            ~, &, |, $, >>, <<;
+
+export hash, ==, show,
+        <, <=, >, >=,
+        -, +, *, ^, /, \, %,
+        ~, &, |, $, >>, <<,
+        Expression, expr,
+        variables, subexpressions;
+
+immutable Expression
+	operator::String
+	arguments::Tuple
+end
+
+Expression(op::String, args::Vararg{Any}) = Expression(op, map(string, args));
+
+function (e::Expression)(args::Vararg{Any})
+    if ((length(e.arguments) == 0) && is_logic_symbol(e.operator))
+        return Expression(e.operator, map(string, args));
+    else
+        error("ExpressionError: ", e, " is not a Symbol (Nullary Expression)!");
+    end
+end
+
+# Hashing Expressions and n-Tuple of Expression(s).
+
+hash(e::Expression, h::UInt) = ((hash(e.operator) $ hash(e.arguments)) $ h);
+
+hash(t_e::Tuple{Vararg{Expression}}, h::UInt) = reduce($, vcat(map(hash, collect(t_e)), h));
+
+<(e1::Expression, e2::Expression) = Expression("<", e1, e2);
+
+<=(e1::Expression, e2::Expression) = Expression("<=", e1, e2);
+
+>(e1::Expression, e2::Expression) = Expression(">", e1, e2);
+
+>=(e1::Expression, e2::Expression) = Expression(">=", e1, e2);
+
+-(e1::Expression) = Expression("-", e1);
+
++(e1::Expression) = Expression("+", e1);
+
+-(e1::Expression, e2::Expression) = Expression("-", e1, e2);
+
++(e1::Expression, e2::Expression) = Expression("+", e1, e2);
+
+*(e1::Expression, e2::Expression) = Expression("*", e1, e2);
+
+^(e1::Expression, e2::Expression) = Expression("^", e1, e2);
+
+/(e1::Expression, e2::Expression) = Expression("/", e1, e2);
+
+\(e1::Expression, e2::Expression) = Expression("\\", e1, e2);
+
+%(e1::Expression, e2::Expression) = Expression("<=>", e1, e2);
+
+~(e::Expression) = Expression("~", e);
+
+(&)(e1::Expression, e2::Expression) = Expression("&", e1, e2);
+
+|(e1::Expression, e2::Expression) = Expression("|", e1, e2);
+
+($)(e1::Expression, e2::Expression) = Expression("=/=", e1, e2);
+
+>>(e1::Expression, e2::Expression) = Expression("==>", e1, e2);
+
+<<(e1::Expression, e2::Expression) = Expression("<==", e1, e2);
+
+==(e1::Expression, e2::Expression) = ((e1.operator == e2.operator) && (e1.arguments == e2.arguments));
+
+function show(e::Expression)
+    if (length(e.arguments) == 0)
+        return e.operator;
+    elseif (is_logic_symbol(e.operator))
+        return @sprintf("%s(%s)", e.operator, join(map(show, map(Expression, e.arguments)), ", "));
+    elseif (length(e.arguments) == 1)
+        return @sprintf("%s(%s)", e.operator, show(Expression(e.arguments[1])));
+    else
+        return @sprintf("(%s)", join(map(show, map(Expression, map(string, e.arguments))), @sprintf(" %s ", e.operator)));
+    end
+end
+
+function show(io::IO, e::Expression)
+    print(io, show(e));
+    nothing;
+end
+
+function is_logic_symbol(s::String)
+    if (length(s) == 0)
+        return false;
+    else
+        return isalpha(s);
+    end
+end
+
+function is_logic_variable_symbol(s::String)
+    return (is_logic_symbol(s) && islower(s[1]));
+end
+
+function is_logic_variable(e::Expression)
+    return ((length(e.arguments) == 0) && islower(e.operator))
+end
+
+"""
+    is_logic_proposition_symbol(s)
+
+Return if the given 's' is an initial uppercase String that is not 'TRUE' or 'FALSE'.
+"""
+function is_logic_proposition_symbol(s::String)
+    return (is_logic_symbol(s) && isupper(s[1]) && (s != "TRUE") && (s != "FALSE"));
+end
+
+function expr(s::String)
+    for (op, new_op) in (("==>", ">>"), ("<==", "<<"), ("<=>", "%"), ("=/=", "\$"))
+        s = replace(s, op, new_op);
+    end
+    return eval(parse(s));
+end
+
+function expr(e::Expression)
+    return e;
+end
+
+function subexpressions(e::Expression)
+    local answer::AbstractVector = [e];
+    for arg in e.arguments
+        answer = vcat(answer, subexpressions(expr(string(arg))));
+    end
+    return answer;
+end
+
+function subexpressions(e::Int)
+    local answer::AbstractVector = [Expression(string(e))];
+    return answer;
+end
+
+
+function variables(e::Expression)
+    return Set(x for x in subexpressions(e) if is_logic_variable(x));
+end
+
+
+

--- a/logic.jl
+++ b/logic.jl
@@ -354,10 +354,10 @@ function walksat(clauses::Array{Expression, 1}; p::Float64=0.5, max_flips::Int64
             symbol = rand(RandomDeviceInstance, proposition_symbols(clause));
         else
             symbol = argmax(proposition_symbols(clause),
-                            (function(e,; sat_model::Dict=model, sat_clauses::AbstractVector=clauses)
-                                sat_model[e] = !sat_model[e];
-                                count = length((collect(c for c in clauses if (pl_true(c, model=sat_model)))));
-                                sat_model[e] = !sat_model[e];
+                            (function(e)
+                                model[e] = !model[e];
+                                count = length((collect(c for c in clauses if (pl_true(c, model=model)))));
+                                model[e] = !model[e];
                                 return count;
                             end));
         end

--- a/logic.jl
+++ b/logic.jl
@@ -2,7 +2,7 @@
 import Base: hash, ==, show;
 
 export hash, ==, show,
-        Expression, expr,
+        Expression, expr, pretty_set,
         variables, subexpressions, proposition_symbols,
         tt_entails, pl_true, tt_true,
         to_conjunctive_normal_form,

--- a/logic.jl
+++ b/logic.jl
@@ -11,7 +11,8 @@ export hash, ==, show,
         AbstractKnowledgeBase, PropositionalKnowledgeBase,
         KnowledgeBaseAgentProgram,
         make_percept_sentence, make_action_query, make_action_sentence, execute,
-        tell, ask, retract;
+        tell, ask, retract,
+        pl_resolution, pl_resolve;
 
 abstract AgentProgram;      #declare AgentProgram as a supertype for AgentProgram implementations
 
@@ -447,7 +448,7 @@ function pl_resolve(c_i::Expression, c_j::Expression)
     for d_i in disjuncts(c_i)
         for d_j in disjuncts(c_j)
             if ((d_i == Expression("~", d_j)) || (Expression("~", d_i) == d_j))
-                d_new = Tuple((collect(Set{Expression}(append!(removeall(disjuncts(c_i), d_i), removeall(disjuncts(c_j), c_j))))...));
+                d_new = Tuple((collect(Set{Expression}(append!(removeall(disjuncts(c_i), d_i), removeall(disjuncts(c_j), d_j))))...));
                 push!(clauses, associate("|", d_new));
             end
         end

--- a/logic.jl
+++ b/logic.jl
@@ -8,11 +8,11 @@ export hash, ==, show,
         to_conjunctive_normal_form,
         eliminate_implications, move_not_inwards, distribute_and_over_or,
         associate, dissociate, conjuncts, disjuncts,
-        AbstractKnowledgeBase, PropositionalKnowledgeBase,
+        AbstractKnowledgeBase, PropositionalKnowledgeBase, PropositionalDefiniteKnowledgeBase,
         KnowledgeBaseAgentProgram,
         make_percept_sentence, make_action_query, make_action_sentence, execute,
-        tell, ask, retract,
-        pl_resolution, pl_resolve;
+        tell, ask, retract, clauses_with_premise,
+        pl_resolution, pl_resolve, pl_fc_entails;
 
 abstract AgentProgram;      #declare AgentProgram as a supertype for AgentProgram implementations
 

--- a/logic.jl
+++ b/logic.jl
@@ -158,6 +158,13 @@ function tt_check_all(kb::Expression, alpha::Expression, symbols::AbstractVector
     end
 end
 
+function tt_true(alpha::Expression)
+    return tt_entails(Expression("TRUE"), alpha);
+end
+
+function tt_true(alpha::String)
+    return tt_entails(Expression("TRUE"), expr(alpha));
+end
 
 """
     extend(dict, key, val)

--- a/logic.jl
+++ b/logic.jl
@@ -16,7 +16,7 @@ immutable Expression
 	arguments::Tuple
 end
 
-Expression(op::String, args::Vararg{Any}) = Expression(op, map(string, args));
+Expression(op::String, args::Vararg{Any}) = Expression(op, map(Expression, args));
 
 function (e::Expression)(args::Vararg{Any})
     if ((length(e.arguments) == 0) && is_logic_symbol(e.operator))
@@ -31,44 +31,6 @@ end
 hash(e::Expression, h::UInt) = ((hash(e.operator) $ hash(e.arguments)) $ h);
 
 hash(t_e::Tuple{Vararg{Expression}}, h::UInt) = reduce($, vcat(map(hash, collect(t_e)), h));
-
-<(e1::Expression, e2::Expression) = Expression("<", e1, e2);
-
-<=(e1::Expression, e2::Expression) = Expression("<=", e1, e2);
-
->(e1::Expression, e2::Expression) = Expression(">", e1, e2);
-
->=(e1::Expression, e2::Expression) = Expression(">=", e1, e2);
-
--(e1::Expression) = Expression("-", e1);
-
-+(e1::Expression) = Expression("+", e1);
-
--(e1::Expression, e2::Expression) = Expression("-", e1, e2);
-
-+(e1::Expression, e2::Expression) = Expression("+", e1, e2);
-
-*(e1::Expression, e2::Expression) = Expression("*", e1, e2);
-
-^(e1::Expression, e2::Expression) = Expression("^", e1, e2);
-
-/(e1::Expression, e2::Expression) = Expression("/", e1, e2);
-
-\(e1::Expression, e2::Expression) = Expression("\\", e1, e2);
-
-%(e1::Expression, e2::Expression) = Expression("<=>", e1, e2);
-
-~(e::Expression) = Expression("~", e);
-
-(&)(e1::Expression, e2::Expression) = Expression("&", e1, e2);
-
-|(e1::Expression, e2::Expression) = Expression("|", e1, e2);
-
-($)(e1::Expression, e2::Expression) = Expression("=/=", e1, e2);
-
->>(e1::Expression, e2::Expression) = Expression("==>", e1, e2);
-
-<<(e1::Expression, e2::Expression) = Expression("<==", e1, e2);
 
 ==(e1::Expression, e2::Expression) = ((e1.operator == e2.operator) && (e1.arguments == e2.arguments));
 
@@ -114,11 +76,18 @@ function is_logic_proposition_symbol(s::String)
     return (is_logic_symbol(s) && isupper(s[1]) && (s != "TRUE") && (s != "FALSE"));
 end
 
+"""
+    expr(s::String)
+
+Parse the given String as an Expression and return the parsed Expression.
+"""
 function expr(s::String)
-    for (op, new_op) in (("==>", ">>"), ("<==", "<<"), ("<=>", "%"), ("=/=", "\$"))
-        s = replace(s, op, new_op);
-    end
-    return eval(parse(s));
+    local tokens::AbstractVector = identify_tokens(s);
+    tokens = parenthesize_tokens(tokens);
+    tokens = parenthesize_arguments(tokens);
+    local root_node::ExpressionNode = construct_expression_tree(tokens);
+    root_node = prune_nodes(root_node);
+    return evaluate_expression_tree(root_node);
 end
 
 function expr(e::Expression)
@@ -128,7 +97,8 @@ end
 function subexpressions(e::Expression)
     local answer::AbstractVector = [e];
     for arg in e.arguments
-        answer = vcat(answer, subexpressions(expr(string(arg))));
+        #answer = vcat(answer, subexpressions(expr(string(arg))));
+        answer = vcat(answer, subexpressions(arg));
     end
     return answer;
 end
@@ -143,5 +113,439 @@ function variables(e::Expression)
     return Set(x for x in subexpressions(e) if is_logic_variable(x));
 end
 
+type ExpressionNode
+    value::Nullable{String}
+    parent::Nullable{ExpressionNode}
+    children::Array{ExpressionNode, 1}
 
+    function ExpressionNode(;val::Union{Void, String}=nothing, parent::Union{Void, ExpressionNode}=nothing)
+        return new(Nullable{String}(val), Nullable{ExpressionNode}(parent), []);
+    end
+end
+
+function identify_tokens(s::String)
+    local existing_parenthesis::Int64 = 0;
+    local queue::Array{String, 1} = Array{String, 1}([]);
+    local current_string::Array{Char, 1} = Array{Char, 1}([]);
+    local isOperator::Bool = false;
+    for character in s
+        if (character == '(')
+            existing_parenthesis = existing_parenthesis + 1;
+
+            if (strip(String(current_string)) != "")
+                push!(queue, strip(String(current_string)));
+            end
+            push!(queue, "(");
+
+            if (isOperator)
+                isOperator = false;
+            end
+            current_string = Array{Char, 1}([]);
+        elseif (character == ')')
+            existing_parenthesis = existing_parenthesis - 1;
+
+            if (strip(String(current_string)) != "")
+                push!(queue, strip(String(current_string)));
+            end
+            push!(queue, ")");
+
+            if (isOperator) #operators can't be leaves
+                error("ConstructExpressionTreeError: Detected operator at leaf level!");
+            end
+
+            current_string = Array{Char, 1}([]);
+        elseif (character == ',')
+            if (strip(String(current_string)) == "")
+                if (queue[length(queue)] == ")")    #do nothing
+                else
+                    error("ConstructExpressionTreeError: Invalid n-Tuple detected!");
+                end
+            else
+                push!(queue, strip(String(current_string)));
+            end
+
+            push!(queue, ",");
+
+            current_string = Array{Char, 1}([]);
+        elseif (character == ' ')   #white space is considered
+            if (isOperator)
+                push!(queue, strip(String(current_string)));
+                current_string = Array{Char, 1}([]);
+                isOperator = false;
+            end
+
+            push!(current_string, character);
+        elseif (character in ('+', '-', '*', '/', '\\', '=', '<', '>', '\$', '|', '%', '^', '~', '&', '?'))
+            if (!isOperator)
+                if (strip(String(current_string)) != "")
+                    push!(queue, strip(String(current_string)));
+                end
+                current_string = Array{Char, 1}([]);
+            end
+            push!(current_string, character);
+            isOperator = true;
+        else    #found new symbol  
+            if (isOperator) #first character of new token
+                push!(queue, strip(String(current_string)));
+                current_string = Array{Char, 1}([]);
+                isOperator = false;
+            end
+            push!(current_string, character);
+        end
+
+
+        if (existing_parenthesis < 0)
+            error("ConstructExpressionTreeError: Invalid parentheses syntax detected!");
+        end
+    end
+    #Check for a possible token at the end of the String.
+    if (strip(String(current_string)) != "")
+        push!(queue, strip(String(current_string)));
+    end
+
+    if (existing_parenthesis != 0)
+        error("ConstructExpressionTreeError: Invalid number of parentheses!");
+    end
+    return queue;
+end
+
+#Parenthesize any arguments that are not enclosed by parentheses
+function parenthesize_arguments(tokens::AbstractVector) 
+    local existing_parenthesis::Int64 = 0;
+    local comma_indices::Array{Int64, 1} = Array{Int64, 1}([]);
+    #keep track of opening and closing parentheses indices
+    #keep track of comma indices at the same tree level
+    #this function runs after parenthesize_tokens()
+    for index in 1:length(tokens)
+        if (tokens[index] == ",")
+            push!(comma_indices, index);
+        end
+    end
+    for comma_index in reverse(comma_indices)
+        ####println("index to modify: ", comma_index, " token: ", tokens[comma_index],
+        ####        " comma indices: ", comma_indices, " tokens: ", tokens...);
+        no_parentheses = false; #boolean indicating if the current argument is enclosed in parentheses
+        #,=>    #the order of indices to search rightward
+        existing_parenthesis = 0;
+        for index in (comma_index + 1):length(tokens)
+            if (tokens[index] == "(")
+                existing_parenthesis = existing_parenthesis + 1;
+            elseif (tokens[index] == ")")
+                existing_parenthesis = existing_parenthesis - 1;
+                if (index == (comma_index + 1))
+                    error("ConstructExpressionTreeError: Found ')', expected argument!");
+                end
+            elseif (tokens[index] == ",")
+                if (existing_parenthesis == 0)  #found following comma in same tree level
+                    #Add parentheses
+                    if (no_parentheses)
+                        insert!(tokens, index, ")");
+                        insert!(tokens, (comma_index + 1), "(");
+                    end
+                    break;
+                end
+            else
+                if (existing_parenthesis == 0)  #the current argument is not enclosed in parentheses
+                    no_parentheses = true;
+                end
+            end
+
+            if (existing_parenthesis == -1) #found end of arguments for infix function
+                ####println("index: ", index, " token: ", tokens[index], " no_parentheses: ", no_parentheses);
+                #Add parentheses
+                if (no_parentheses)
+                    insert!(tokens, index, ")");
+                    insert!(tokens, (comma_index + 1), "(");
+                end
+                break;
+            end
+        end
+        no_parentheses = false; #boolean indicating if the current argument is enclosed in parentheses
+        #<=,    #reverse the order of indices to search leftward
+        existing_parenthesis = 0;
+        for index in reverse(1:(comma_index - 1))
+            if (tokens[index] == "(")
+                existing_parenthesis = existing_parenthesis + 1;
+                if (index == (comma_index - 1))
+                    error("ConstructExpressionTreeError: Found '(', expected argument!");
+                end
+            elseif (tokens[index] == ")")
+                existing_parenthesis = existing_parenthesis - 1;
+            elseif (tokens[index] == ",")
+                if (existing_parenthesis == 0)  #found following comma in same tree level
+                    #Add parentheses
+                    if (no_parentheses)
+                        insert!(tokens, comma_index, ")");
+                        insert!(tokens, (index + 1), "(");
+                    end
+                    break;
+                end
+            else
+                if (existing_parenthesis == 0)  #the current argument is not enclosed in parentheses
+                    no_parentheses = true;
+                end
+            end
+
+            if (existing_parenthesis == 1) #found end of arguments for infix function
+                ####println("index: ", index, " token: ", tokens[index], " no_parentheses: ", no_parentheses);
+                #Add parentheses
+                if (no_parentheses)
+                    insert!(tokens, comma_index, ")");
+                    insert!(tokens, index, "(");
+                end
+                break;
+            end
+        end
+    end
+    return tokens;
+end
+
+function parenthesize_tokens(tokens::AbstractVector)
+    local existing_parenthesis::Int64 = 0;
+    local add_parentheses_at::Array{Int64, 1} = Array{Int64, 1}([]);   #-1 if nothing should be done
+    #Find next prefix operator without a following '('
+    for index in 1:length(tokens)
+        if (any((function(c::Char)
+                        return c in tokens[index];
+                    end),
+                    ('+', '-', '*', '/', '\\', '=', '<', '>', '\$', '|', '%', '^', '~', '&', '?')))
+            #Check if '(' exists already
+            if (((index + 1) != length(tokens) + 1) && (tokens[index + 1] != "("))
+                push!(add_parentheses_at, index);
+            end
+        end
+    end
+    for last_entry_index in reverse(add_parentheses_at)
+        ####println("index to modify: ", last_entry_index, " token: ", tokens[last_entry_index],
+        ####        " tokens: ", tokens...);
+        modified_tokens::Bool = false;
+        for index in (last_entry_index + 1):length(tokens)
+            if (tokens[index] == "(")
+                existing_parenthesis = existing_parenthesis + 1;
+            elseif (tokens[index] == ")")
+                existing_parenthesis = existing_parenthesis - 1;
+            end
+            if (existing_parenthesis == 0)
+                if (((index + 1) < length(tokens)) &&   #'(' should not exist at the end of the expression
+                    (tokens[index + 1] != "("))
+                    insert!(tokens, index + 1, ")");
+                    insert!(tokens, last_entry_index + 1, "(");
+                    modified_tokens = true;
+                    break;
+                elseif (index == length(tokens))
+                    insert!(tokens, index + 1, ")");
+                    insert!(tokens, last_entry_index + 1, "(");
+                    modified_tokens = true;
+                    break;
+                end
+            elseif (existing_parenthesis == -1) #reached higher tree level (')'), ('(') should exist
+                insert!(tokens, index, ")");
+                insert!(tokens, last_entry_index + 1, "(");
+                existing_parenthesis = 0;
+                modified_tokens = true;
+                break;
+            end
+        end
+        if (!modified_tokens)
+            error("ConstructExpressionTreeError: Could not add parentheses to the expression!");
+        end
+    end
+    return tokens;
+end
+
+function construct_expression_tree(tokens::AbstractVector)
+    local existing_parenthesis::Int64 = 0;
+    local current_node::ExpressionNode = ExpressionNode();
+    local root_node::ExpressionNode = current_node;
+    local unary_depth::Int64 = 0;   #when operator exists and we traverse to a new child node
+    for token in tokens
+        if (token == "(")
+            existing_parenthesis = existing_parenthesis + 1;
+
+            #Create new level and visit it
+            new_node = ExpressionNode(parent=current_node);
+            push!(current_node.children, new_node);
+            current_node = new_node;
+        elseif (token == ")")
+            existing_parenthesis = existing_parenthesis - 1;
+            if (!isnull(current_node.parent))
+                current_node = get(current_node.parent);
+            else
+                error("ConstructExpressionTreeError: The root node does not have a parent!");
+            end
+        elseif (token == ",")
+            if (!isnull(current_node.value) && get(current_node.value) != ",")
+                notFound = true;
+                
+                new_intermediate_node = ExpressionNode(val=token, parent=get(current_node.parent));
+                for (i, c) in enumerate(get(current_node.parent).children)
+                    if (c == current_node)
+                        deleteat!(get(current_node.parent).children, i);
+                        insert!(get(current_node.parent).children, i, new_intermediate_node);
+                        notFound = false;
+                        break;
+                    end
+                end
+                if (notFound)
+                    error("ConstructExpressionTreeError: could not find existing child node!");
+                end
+                
+
+                current_node.parent = Nullable{ExpressionNode}(new_intermediate_node);
+                push!(new_intermediate_node.children, current_node);
+                current_node = new_intermediate_node;
+            else
+                current_node.value = Nullable{String}(",");
+            end
+        elseif (any((function(c::Char)
+                        return c in token;
+                    end),
+                    ('+', '-', '*', '/', '\\', '=', '<', '>', '\$', '|', '%', '^', '~', '&', '?')))
+            #Check if operator exists already
+            if (isnull(current_node.value))
+                current_node.value = Nullable{String}(token);
+            else
+                if (!any((function(c::Char)
+                        return c in token;
+                    end),
+                    ('+', '-', '*', '/', '\\', '=', '<', '>', '\$', '|', '%', '^', '~', '&', '?')))
+                    if (isnull(current_node.parent))
+                        new_root_node = ExpressionNode(val=token);
+                        push!(new_root_node.children, current_node);
+                        current_node.parent = new_root_node;
+                        current_node = new_root_node;
+                    else
+                        notFound = true;
+                        new_intermediate_node = ExpressionNode(val=token, parent=get(current_node.parent));
+
+                        for (i, c) in enumerate(get(current_node.parent).children)
+                            if (c == current_node)
+                                deleteat!(get(current_node.parent).children, i);
+                                insert!(get(current_node.parent).children, i, new_intermediate_node);
+                                notFound = false;
+                                break;
+                            end
+                        end
+                        if (notFound)
+                            error("ConstructExpressionTreeError: Could not find existing child node!");
+                        end
+
+                        current_node.parent = Nullable{ExpressionNode}(new_intermediate_node);
+                        push!(new_intermediate_node.children, current_node);
+                        current_node = new_intermediate_node;
+                    end
+                else
+                    if (isnull(current_node.parent))
+                        new_root_node = ExpressionNode(val=token);
+                        current_node.parent = new_root_node;
+                        push!(new_root_node.children, current_node);
+                        current_node = new_root_node;
+                    else
+                        notFound = true;
+                        new_intermediate_node = ExpressionNode(val=token, parent=get(current_node.parent));
+
+                        for (i, c) in enumerate(get(current_node.parent).children)
+                            if (c == current_node)
+                                deleteat!(get(current_node.parent).children, i);
+                                insert!(get(current_node.parent).children, i, new_intermediate_node);
+                                notFound = false;
+                                break;
+                            end
+                        end
+                        if (notFound)
+                            error("ConstructExpressionTreeError: Could not find existing child node!");
+                        end
+
+                        current_node.parent = Nullable{ExpressionNode}(new_intermediate_node);
+                        push!(new_intermediate_node.children, current_node);
+                        current_node = new_intermediate_node;
+                    end
+                end
+            end
+        else    #Not a special operator
+            if (isnull(current_node.value))
+                current_node.value = Nullable{String}(token);
+            else
+                new_node = ExpressionNode(val=token, parent=current_node);
+                push!(current_node.children, new_node);
+            end
+        end
+
+
+        if (existing_parenthesis < 0)
+            error("ConstructExpressionTreeError: Invalid parentheses syntax detected!");
+        end
+    end
+
+    while (!isnull(root_node.parent))
+        root_node = get(root_node.parent);
+    end
+
+    if (existing_parenthesis != 0)
+        error("ConstructExpressionTreeError: Invalid number of parentheses!");
+    end
+    return root_node;
+end
+
+function prune_nodes(node::ExpressionNode)
+    #remove valueless nodes that have 1 child
+    for child in node.children
+        prune_nodes(child);
+    end
+    if (isnull(node.value))
+        if (length(node.children) == 1)
+            if (isnull(node.parent))
+                new_root_node = pop!(node.children);
+                new_root_node.parent = Nullable{ExpressionNode}();
+                return new_root_node;
+            else
+                notFound = true;
+                new_node = pop!(node.children);
+
+                for (i, c) in enumerate(get(node.parent).children)
+                    if (c == node)
+                        deleteat!(get(current_node.parent).children, i);
+                        insert!(get(current_node.parent).children, i, new_node);
+                        notFound = false;
+                        break;
+                    end
+                end
+                if (notFound)
+                    error("ConstructExpressionTreeError: Could not find existing child node!");
+                end
+
+                new_node.parent = Nullable{ExpressionNode}(current_node.parent);
+                return new_node;
+            end
+        else
+            error("ConstructExpressionTreeError: Found ", length(node.children), " children in valueless ExpressionNode!");
+        end
+    end
+    return node;
+end
+
+function evaluate_expression_tree(node::ExpressionNode)
+    local queue::AbstractVector = [];
+    for child in node.children
+        if (get(child.value) != ",")
+            push!(queue, evaluate_expression_tree(child));
+        else #Use current operator for childrens' children
+            for child_child in child.children
+                push!(queue, evaluate_expression_tree(child_child));
+            end
+        end
+    end
+    if (length(node.children) == 0)
+        return Expression(get(node.value));
+    else
+        return Expression(get(node.value), queue...);
+    end
+end
+
+function pretty_set(s::Set{Expression})
+    return @sprintf("Set(%s)", repr(sort(collect(s),
+                                        lt=(function(e1::Expression, e2::Expression)
+                                                return isless(e1.operator, e2.operator);
+                                            end))));
+end
 

--- a/logic.jl
+++ b/logic.jl
@@ -165,7 +165,7 @@ function is_logic_symbol(s::String)
     if (length(s) == 0)
         return false;
     else
-        return isalpha(s);
+        return isalpha(s[1]);
     end
 end
 

--- a/logic.jl
+++ b/logic.jl
@@ -318,9 +318,9 @@ end
 """
     dpll_satisfiable(s)
 
-Use the Davis-Putname-Logemann-Loveland (DPLL) algorithm (Fig. 7.17) to check satisfiability
-of the given propositional logic sentence 's' and returns the model if the sentence is satisfiable
-and false otherwise.
+Use the Davis-Putnam-Logemann-Loveland (DPLL) algorithm (Fig. 7.17) to check satisfiability
+of the given propositional logic sentence 's' and return the model (dictionary of truth value
+assignments) if the sentence 's' is satisfiable and false otherwise.
 """
 function dpll_satisfiable(s::Expression)
     local clauses = conjuncts(to_conjunctive_normal_form(s));

--- a/logic.jl
+++ b/logic.jl
@@ -9,7 +9,8 @@ export hash, ==, show,
         -, +, *, ^, /, \, %,
         ~, &, |, $, >>, <<,
         Expression, expr,
-        variables, subexpressions;
+        variables, subexpressions, proposition_symbols,
+        tt_entails, pl_true;
 
 immutable Expression
 	operator::String

--- a/tests/run_logic_tests.jl
+++ b/tests/run_logic_tests.jl
@@ -247,3 +247,20 @@ walksat_test(map(expr, ["A & B", "C | D", "~(D | P)"]), solutions=Dict([Pair(Exp
 
 @test (typeof(walksat(map(expr, ["A | B", "B & C", "C | D", "D & A", "P", "~P"]), p=0.5, max_flips=100)) <: Void);
 
+transition = Dict([Pair("A", Dict([Pair("Left", "A"), Pair("Right", "B")])),
+                    Pair("B", Dict([Pair("Left", "A"), Pair("Right", "C")])),
+                    Pair("C", Dict([Pair("Left", "B"), Pair("Right", "C")]))]);
+
+@test (typeof(sat_plan("A", transition,"C", 2)) <: Void);
+
+@test sat_plan("A", transition, "B", 3) == ["Right"];
+
+@test sat_plan("C", transition, "A", 3) == ["Left", "Left"];
+
+transition = Dict([Pair((0, 0), Dict([Pair("Right", (0, 1)), Pair("Down", (1, 0))])),
+                    Pair((0, 1), Dict([Pair("Left", (1, 0)), Pair("Down", (1, 1))])),
+                    Pair((1, 0), Dict([Pair("Right", (1, 0)), Pair("Up", (1, 0)), Pair("Left", (1, 0)), Pair("Down", (1, 0))])),
+                    Pair((1, 1), Dict([Pair("Left", (1, 0)), Pair("Up", (0, 1))]))]);
+
+@test sat_plan((0, 0), transition, (1, 1), 4) == ["Right", "Down"];
+

--- a/tests/run_logic_tests.jl
+++ b/tests/run_logic_tests.jl
@@ -219,3 +219,31 @@ tell(kb_wumpus, expr("B21"));
                 Pair(Expression("E"), false),
                 Pair(Expression("F"), false),]));
 
+function walksat_test(clauses::Array{Expression, 1}; solutions::Dict=Dict())
+    local sln = walksat(clauses);
+    if (!(typeof(sln) <: Void)) #found a satisfiable solution
+        @test all(collect(pl_true(clause, model=sln) for clause in clauses));
+        if (length(solutions) != 0)
+            @test all(collect(pl_true(clause, model=solutions) for clause in clauses));
+            @test sln == solutions;
+        end
+    end
+    nothing;
+end
+
+walksat_test(map(expr, ["A & B", "A & C"]));
+
+walksat_test(map(expr, ["A | B", "P & Q", "P & B"]));
+
+walksat_test(map(expr, ["A & B", "C | D", "~(D | P)"]), solutions=Dict([Pair(Expression("A"), true),
+                                                            Pair(Expression("B"), true),
+                                                            Pair(Expression("C"), true),
+                                                            Pair(Expression("D"), false),
+                                                            Pair(Expression("P"), false),]));
+
+@test (typeof(walksat(map(expr, ["A & ~A"]), p=0.5, max_flips=100)) <: Void);
+
+@test (typeof(walksat(map(expr, ["A | B", "~A", "~(B | C)", "C | D", "P | Q"]), p=0.5, max_flips=100)) <: Void);
+
+@test (typeof(walksat(map(expr, ["A | B", "B & C", "C | D", "D & A", "P", "~P"]), p=0.5, max_flips=100)) <: Void);
+

--- a/tests/run_logic_tests.jl
+++ b/tests/run_logic_tests.jl
@@ -278,3 +278,27 @@ transition = Dict([Pair((0, 0), Dict([Pair("Right", (0, 1)), Pair("Down", (1, 0)
                             Pair(Expression("y"), Expression("0"))]),
                     expr("F(x) + y"))) == "(F(42) + 0)";
 
+function fol_bc_ask_query(q::Expression; kb::Union{Void, AbstractKnowledgeBase}=nothing)
+    local answers::Tuple;
+    if (typeof(kb) <: Void)
+        answers = fol_bc_ask(aimajulia.test_fol_kb, q);
+    else
+        answers = fol_bc_ask(kb, q);
+    end
+    local test_vars = variables(q);
+    return sort(collect(Dict(collect(Pair(k, v) for (k, v) in answer if (k in test_vars))) for answer in answers),
+            lt=(function(d1::Dict, d2::Dict)
+                    return isless(repr(d1), repr(d2));
+                end));
+end
+
+@test fol_bc_ask_query(expr("Farmer(x)")) == [Dict([Pair(Expression("x"), Expression("Mac"))])];
+
+@test fol_bc_ask_query(expr("Human(x)")) == [Dict([Pair(Expression("x"), Expression("Mac"))]),
+                                            Dict([Pair(Expression("x"), Expression("MrsMac"))])];
+
+@test fol_bc_ask_query(expr("Rabbit(x)")) == [Dict([Pair(Expression("x"), Expression("MrsRabbit"))]),
+                                            Dict([Pair(Expression("x"), Expression("Pete"))])];
+
+@test fol_bc_ask_query(expr("Criminal(x)"), kb=aimajulia.crime_kb) == [Dict([Pair(Expression("x"), Expression("West"))])];
+

--- a/tests/run_logic_tests.jl
+++ b/tests/run_logic_tests.jl
@@ -6,36 +6,23 @@ using aimajulia;
 
 #The following Logic tests are from the aima-python doctests
 
-A = Expression("A");
-
-B = Expression("B");
-
-C = Expression("C");
-
-D = Expression("D");
-
-E = Expression("E");
-
-F = Expression("F");
-
-G = Expression("G");
-
-H = Expression("H");
-
 x = Expression("x");
 
 y = Expression("y");
 
 z = Expression("z");
 
-P = Expression("P");
+@test variables(expr("F(x, x) & G(x, y) & H(y, z) & R(A, z, z)")) == Set(x, y, z);
 
-Q = Expression("Q");
+@test variables(expr("F(x, A, y)")) == Set(x, y);
 
-R = Expression("R");
-
-S = Expression("S");
-
-@test variables(expr("F(x, x) & G(x, y) & H(y, z) & R(A, z, 2)")) == Set(x, y, z);
+@test variables(expr("F(G(x), z)")) == Set(x, z);
 
 @test show(expr("P & Q ==> Q")) == "((P & Q) ==> Q)";
+
+@test show(expr("P ==> Q(1)")) == "(P ==> Q(1))";
+
+@test show(expr("P & Q | ~R(x, F(x))")) == "((P & Q) | ~(R(x, F(x))))";
+
+@test show(expr("P & Q ==> R & S")) == "(((P & Q) ==> R) & S)";
+

--- a/tests/run_logic_tests.jl
+++ b/tests/run_logic_tests.jl
@@ -302,3 +302,7 @@ end
 
 @test fol_bc_ask_query(expr("Criminal(x)"), kb=aimajulia.crime_kb) == [Dict([Pair(Expression("x"), Expression("West"))])];
 
+@test differentiate(expr("x * x", expr("x"))) == expr("(x * 1) + (x * 1)");
+
+@test differentiate_simplify(expr("x * x", expr("x"))) == expr("2 * x");
+

--- a/tests/run_logic_tests.jl
+++ b/tests/run_logic_tests.jl
@@ -91,6 +91,11 @@ z = Expression("z");
 
 @test disjuncts(expr("A & B")) == [expr("A & B")];
 
+@test repr(to_conjunctive_normal_form(Expression("&",
+                                                aimajulia.wumpus_world_inference,
+                                                Expression("~", expr("~P12"))))) ==
+                                                "((~(P12) | B11) & (~(P21) | B11) & (P12 | P21 | ~(B11)) & ~(B11) & P12)";
+
 @test to_conjunctive_normal_form(expr("~(B | C)")) == expr("~B & ~C");
 
 @test repr(to_conjunctive_normal_form(expr("~(B | C)"))) == "(~(B) & ~(C))";
@@ -174,4 +179,8 @@ tell(kb_wumpus, expr("B21"));
 
 # Found a pit in either (3, 1) or (2,2).
 @test ask(kb_wumpus, expr("P22 | P31")) == Dict([]);
+
+@test pl_fc_entails(aimajulia.horn_clauses_kb, Expression("Q")) == true;
+
+@test pl_fc_entails(aimajulia.horn_clauses_kb, Expression("SomethingSilly")) == false;
 

--- a/tests/run_logic_tests.jl
+++ b/tests/run_logic_tests.jl
@@ -115,3 +115,29 @@ z = Expression("z");
 
 @test repr(to_conjunctive_normal_form(expr("A | (B | (C | (D & E)))"))) == "((D | A | B | C) & (E | A | B | C))";
 
+prop_kb = PropositionalKnowledgeBase();
+
+@test count((function(item)
+                if (typeof(item) <: Bool)
+                    return item;
+                else
+                    return true;
+                end
+            end), collect(ask(prop_kb, e) for e in map(expr, ["A", "C", "D", "E", "Q"]))) == 0;
+
+tell(prop_kb, expr("A & E"));
+
+@test ask(prop_kb, expr("A")) == Dict([]);
+
+@test ask(prop_kb, expr("E")) == Dict([]);
+
+tell(prop_kb, expr("E ==> C"));
+
+@test ask(prop_kb, expr("C")) == Dict([]);
+
+retract(prop_kb, expr("E"));
+
+@test ask(prop_kb, expr("E")) == false;
+
+@test ask(prop_kb, expr("C")) == false;
+

--- a/tests/run_logic_tests.jl
+++ b/tests/run_logic_tests.jl
@@ -79,7 +79,7 @@ z = Expression("z");
 
 @test distribute_and_over_or(expr("(A & B) | C")) == expr("(A | C) & (B | C)");
 
-@test associate("&", (expr("A & B"), expr("B | C"), expr("B & C")));
+@test associate("&", (expr("A & B"), expr("B | C"), expr("B & C"))) == expr("&(A, B, (B | C), B, C)");
 
 @test associate("|", (expr("A | (B | (C | (A & B)))"),)) == expr("|(A, B, C, (A & B))");
 

--- a/tests/run_logic_tests.jl
+++ b/tests/run_logic_tests.jl
@@ -302,7 +302,7 @@ end
 
 @test fol_bc_ask_query(expr("Criminal(x)"), kb=aimajulia.crime_kb) == [Dict([Pair(Expression("x"), Expression("West"))])];
 
-@test differentiate(expr("x * x", expr("x"))) == expr("(x * 1) + (x * 1)");
+@test differentiate(expr("x * x"), expr("x")) == expr("(x * 1) + (x * 1)");
 
-@test differentiate_simplify(expr("x * x", expr("x"))) == expr("2 * x");
+@test differentiate_simplify(expr("x * x"), expr("x")) == expr("2 * x");
 

--- a/tests/run_logic_tests.jl
+++ b/tests/run_logic_tests.jl
@@ -141,3 +141,10 @@ retract(prop_kb, expr("E"));
 
 @test ask(prop_kb, expr("C")) == false;
 
+plr_results = pl_resolve(to_conjunctive_normal_form(expr("A | B | C")),
+                        to_conjunctive_normal_form(expr("~B | ~C | F")));
+
+@test pretty_set(Set{Expression}(disjuncts(plr_results[1]))) == "Set(Expression[A,C,F,~(C)])";
+
+@test pretty_set(Set{Expression}(disjuncts(plr_results[2]))) == "Set(Expression[A,B,F,~(B)])";
+

--- a/tests/run_logic_tests.jl
+++ b/tests/run_logic_tests.jl
@@ -184,3 +184,38 @@ tell(kb_wumpus, expr("B21"));
 
 @test pl_fc_entails(aimajulia.horn_clauses_kb, Expression("SomethingSilly")) == false;
 
+@test inspect_literal(Expression("P")) == (Expression("P"), true);
+
+@test inspect_literal(Expression("~", Expression("P"))) == (Expression("P"), false);
+
+@test unit_clause_assign(expr("A | B | C"), Dict([Pair(Expression("A"), true)])) == (nothing, nothing);
+
+@test unit_clause_assign(expr("B | ~C"), Dict([Pair(Expression("A"), true)])) == (nothing, nothing);
+
+@test unit_clause_assign(expr("B | C"), Dict([Pair(Expression("A"), true)])) == (nothing, nothing);
+
+@test unit_clause_assign(expr("~A | ~B"), Dict([Pair(Expression("A"), true)])) == (Expression("B"), false);
+
+@test unit_clause_assign(expr("B | ~A"), Dict([Pair(Expression("A"), true)])) == (Expression("B"), true);
+
+@test find_unit_clause(map(expr, ["A | B | C", "B | ~C", "~A | ~B"]), Dict([Pair(Expression("A"), true)])) == (Expression("B"), false);
+
+@test find_pure_symbol(map(expr, ["A", "B", "C"]), map(expr, ["A | ~B", "~B | ~C", "C | A"])) == (Expression("A"), true);
+
+@test find_pure_symbol(map(expr, ["A", "B", "C"]), map(expr, ["~A | ~B", "~B | ~C", "C | A"])) == (Expression("B"), false);
+
+@test find_pure_symbol(map(expr, ["A", "B", "C"]), map(expr, ["~A | B", "~B | ~C", "C | A"])) == (nothing, nothing);
+
+@test dpll_satisfiable(expr("A & ~B")) == Dict([Pair(Expression("A"), true),
+                                                Pair(Expression("B"), false),]);
+
+@test dpll_satisfiable(expr("P & ~P")) == false;
+
+@test (dpll_satisfiable(expr("A & ~B & C & (A | ~D) & (~E | ~D) & (C | ~D) & (~A | ~F) & (E | ~F) & (~D | ~F) & (B | ~C | D) & (A | ~E | F) & (~A | E | D)"))
+        == Dict([Pair(Expression("A"), true),
+                Pair(Expression("B"), false),
+                Pair(Expression("C"), true),
+                Pair(Expression("D"), true),
+                Pair(Expression("E"), false),
+                Pair(Expression("F"), false),]));
+

--- a/tests/run_logic_tests.jl
+++ b/tests/run_logic_tests.jl
@@ -12,11 +12,11 @@ y = Expression("y");
 
 z = Expression("z");
 
-@test variables(expr("F(x, x) & G(x, y) & H(y, z) & R(A, z, z)")) == Set(x, y, z);
+@test variables(expr("F(x, x) & G(x, y) & H(y, z) & R(A, z, z)")) == Set([x, y, z]);
 
-@test variables(expr("F(x, A, y)")) == Set(x, y);
+@test variables(expr("F(x, A, y)")) == Set([x, y]);
 
-@test variables(expr("F(G(x), z)")) == Set(x, z);
+@test variables(expr("F(G(x), z)")) == Set([x, z]);
 
 @test show(expr("P & Q ==> Q")) == "((P & Q) ==> Q)";
 

--- a/tests/run_logic_tests.jl
+++ b/tests/run_logic_tests.jl
@@ -144,7 +144,7 @@ retract(prop_kb, expr("E"));
 plr_results = pl_resolve(to_conjunctive_normal_form(expr("A | B | C")),
                         to_conjunctive_normal_form(expr("~B | ~C | F")));
 
-@test pretty_set(Set{Expression}(disjuncts(plr_results[1]))) == "Set(Expression[A,C,F,~(C)])";
+@test pretty_set(Set{Expression}(disjuncts(plr_results[1]))) == "Set(aimajulia.Expression[A,C,F,~(C)])";
 
-@test pretty_set(Set{Expression}(disjuncts(plr_results[2]))) == "Set(Expression[A,B,F,~(B)])";
+@test pretty_set(Set{Expression}(disjuncts(plr_results[2]))) == "Set(aimajulia.Expression[A,B,F,~(B)])";
 

--- a/tests/run_logic_tests.jl
+++ b/tests/run_logic_tests.jl
@@ -1,0 +1,41 @@
+include("../aimajulia.jl");
+
+using Base.Test;
+
+using aimajulia;
+
+#The following Logic tests are from the aima-python doctests
+
+A = Expression("A");
+
+B = Expression("B");
+
+C = Expression("C");
+
+D = Expression("D");
+
+E = Expression("E");
+
+F = Expression("F");
+
+G = Expression("G");
+
+H = Expression("H");
+
+x = Expression("x");
+
+y = Expression("y");
+
+z = Expression("z");
+
+P = Expression("P");
+
+Q = Expression("Q");
+
+R = Expression("R");
+
+S = Expression("S");
+
+@test variables(expr("F(x, x) & G(x, y) & H(y, z) & R(A, z, 2)")) == Set(x, y, z);
+
+@test show(expr("P & Q ==> Q")) == "((P & Q) ==> Q)";

--- a/tests/run_logic_tests.jl
+++ b/tests/run_logic_tests.jl
@@ -264,3 +264,17 @@ transition = Dict([Pair((0, 0), Dict([Pair("Right", (0, 1)), Pair("Down", (1, 0)
 
 @test sat_plan((0, 0), transition, (1, 1), 4) == ["Right", "Down"];
 
+@test unify(expr("x + y"), expr("y + C"), Dict([])) == Dict([Pair(Expression("x"), Expression("y")),
+                                                            Pair(Expression("y"), Expression("C"))]);
+
+@test unify(expr("x"), expr("3"), Dict([])) == Dict([Pair(Expression("x"), Expression("3"))]);
+
+@test unify(expr("x"), expr("x"), Dict([])) == Dict([]);
+
+@test extend(Dict([Pair(Expression("x"), 1)]), Expression("y"), 2) == Dict([Pair(Expression("x"), 1),
+                                                                            Pair(Expression("y"), 2)]);
+
+@test repr(substitute(Dict([Pair(Expression("x"), Expression("42")),
+                            Pair(Expression("y"), Expression("0"))]),
+                    expr("F(x) + y"))) == "(F(42) + 0)";
+

--- a/tests/run_logic_tests.jl
+++ b/tests/run_logic_tests.jl
@@ -67,3 +67,51 @@ z = Expression("z");
 
 @test typeof(pl_true(expr("P | ~P"))) <: Void;
 
+@test eliminate_implications(expr("A ==> (~B <== C)")) == expr("(~B | ~C) | ~A");
+
+@test eliminate_implications(expr("A ^ B")) == expr("(A & ~B) | (~A & B)");
+
+@test move_not_inwards(expr("~(A | B)")) == expr("~A & ~B");
+
+@test move_not_inwards(expr("~(A & B)")) == expr("~A | ~B");
+
+@test move_not_inwards(expr("~(~(A | ~B) | ~(~C))")) == expr("(A | ~B) & ~C");
+
+@test distribute_and_over_or(expr("(A & B) | C")) == expr("(A | C) & (B | C)");
+
+@test associate("&", (expr("A & B"), expr("B | C"), expr("B & C")));
+
+@test associate("|", (expr("A | (B | (C | (A & B)))"),)) == expr("|(A, B, C, (A & B))");
+
+@test conjuncts(expr("A & B")) == [Expression("A"), Expression("B")];
+
+@test conjuncts(expr("A | B")) == [expr("A | B")];
+
+@test disjuncts(expr("A | B")) == [Expression("A"), Expression("B")];
+
+@test disjuncts(expr("A & B")) == [expr("A & B")];
+
+@test to_conjunctive_normal_form(expr("~(B | C)")) == expr("~B & ~C");
+
+@test repr(to_conjunctive_normal_form(expr("~(B | C)"))) == "(~(B) & ~(C))";
+
+@test to_conjunctive_normal_form(expr("(P & Q) | (~P & ~Q)")) == expr("&((~P | P), (~Q | P), (~P | Q), (~Q | Q))");
+
+@test repr(to_conjunctive_normal_form(expr("(P & Q) | (~P & ~Q)"))) == "((~(P) | P) & (~(Q) | P) & (~(P) | Q) & (~(Q) | Q))";
+
+@test to_conjunctive_normal_form(expr("B <=> (P1 | P2)")) == expr("&((~P1 | B), (~P2 | B), |(P1, P2, ~B))");
+
+@test repr(to_conjunctive_normal_form(expr("B <=> (P1 | P2)"))) == "((~(P1) | B) & (~(P2) | B) & (P1 | P2 | ~(B)))";
+
+@test to_conjunctive_normal_form(expr("a | (b & c) | d")) == expr("|(b, a, d) & |(c, a, d)");
+
+@test repr(to_conjunctive_normal_form(expr("a | (b & c) | d"))) == "((b | a | d) & (c | a | d))";
+
+@test to_conjunctive_normal_form(expr("A & (B | (D & E))")) == expr("&(A, (D | B), (E | B))");
+
+@test repr(to_conjunctive_normal_form(expr("A & (B | (D & E))"))) == "(A & (D | B) & (E | B))";
+
+@test to_conjunctive_normal_form(expr("A | (B | (C | (D & E)))")) == expr("|(D, A, B, C) & |(E, A, B, C)");
+
+@test repr(to_conjunctive_normal_form(expr("A | (B | (C | (D & E)))"))) == "((D | A | B | C) & (E | A | B | C))";
+

--- a/tests/run_logic_tests.jl
+++ b/tests/run_logic_tests.jl
@@ -148,3 +148,30 @@ plr_results = pl_resolve(to_conjunctive_normal_form(expr("A | B | C")),
 
 @test pretty_set(Set{Expression}(disjuncts(plr_results[2]))) == "Set(aimajulia.Expression[A,B,F,~(B)])";
 
+# Use PropositionalKnowledgeBase to represent the Wumpus World (Fig. 7.4)
+
+kb_wumpus = PropositionalKnowledgeBase();
+tell(kb_wumpus, expr("~P11"));
+tell(kb_wumpus, expr("B11 <=> (P12 | P21)"));
+tell(kb_wumpus, expr("B21 <=> (P11 | P22 | P31)"));
+tell(kb_wumpus, expr("~B11"));
+tell(kb_wumpus, expr("B21"));
+
+# Can't find a pit at location (1, 1).
+@test ask(kb_wumpus, expr("~P11")) == Dict([]);
+
+# Can't find a pit at location (1, 2).
+@test ask(kb_wumpus, expr("~P12")) == Dict([]);
+
+# Found pit at location (2, 2).
+@test ask(kb_wumpus, expr("P22")) == false;
+
+# Found pit at location (3, 1).
+@test ask(kb_wumpus, expr("P31")) == false;
+
+# Locations (1, 2) and (2, 1) do not contain pits.
+@test ask(kb_wumpus, expr("~P12 & ~P21")) == Dict([]);
+
+# Found a pit in either (3, 1) or (2,2).
+@test ask(kb_wumpus, expr("P22 | P31")) == Dict([]);
+

--- a/tests/run_logic_tests.jl
+++ b/tests/run_logic_tests.jl
@@ -36,6 +36,8 @@ z = Expression("z");
 
 @test proposition_symbols(expr("(x & B(z)) ==> Farmer(y) | A")) == [Expression("A"), expr("Farmer(y)"), expr("B(z)")];
 
+@test tt_true("(P ==> Q) <=> (~P | Q)") == true;
+
 @test typeof(pl_true(Expression("P"))) <: Void;
 
 @test typeof(pl_true(expr("P | P"))) <: Void;

--- a/tests/run_logic_tests.jl
+++ b/tests/run_logic_tests.jl
@@ -26,6 +26,16 @@ z = Expression("z");
 
 @test show(expr("P & Q ==> R & S")) == "(((P & Q) ==> R) & S)";
 
+@test tt_entails(expr("P & Q"), expr("Q")) == true;
+
+@test tt_entails(expr("P | Q"), expr("Q")) == false;
+
+@test tt_entails(expr("A & (B | C) & E & F & ~(P | Q)"), expr("A & E & F & ~P & ~Q")) == true;
+
+@test proposition_symbols(expr("x & y & z | A")) == [Expression("A")];
+
+@test proposition_symbols(expr("(x & B(z)) ==> Farmer(y) | A")) == [Expression("A"), expr("Farmer(y)"), expr("B(z)")];
+
 @test typeof(pl_true(Expression("P"))) <: Void;
 
 @test typeof(pl_true(expr("P | P"))) <: Void;

--- a/tests/run_logic_tests.jl
+++ b/tests/run_logic_tests.jl
@@ -26,3 +26,32 @@ z = Expression("z");
 
 @test show(expr("P & Q ==> R & S")) == "(((P & Q) ==> R) & S)";
 
+@test typeof(pl_true(Expression("P"))) <: Void;
+
+@test typeof(pl_true(expr("P | P"))) <: Void;
+
+@test pl_true(expr("P | Q"), model=Dict([Pair(Expression("P"), true)])) == true;
+
+@test pl_true(expr("(A | B) & (C | D)"),
+                model=Dict([Pair(Expression("A"), false),
+                            Pair(Expression("B"), true),
+                            Pair(Expression("C"), true)])) == true;
+
+@test pl_true(expr("(A & B) & (C | D)"),
+                model=Dict([Pair(Expression("A"), false),
+                            Pair(Expression("B"), true),
+                            Pair(Expression("C"), true)])) == false;
+
+@test pl_true(expr("(A & B) | (A & C)"),
+                model=Dict([Pair(Expression("A"), false),
+                            Pair(Expression("B"), true),
+                            Pair(Expression("C"), true)])) == false;
+
+@test typeof(pl_true(expr("(A | B) & (C | D)"),
+                model=Dict([Pair(Expression("A"), true),
+                            Pair(Expression("D"), false)]))) <: Void;
+
+@test pl_true(Expression("P"), model=Dict([Pair(Expression("P"), false)])) == false;
+
+@test typeof(pl_true(expr("P | ~P"))) <: Void;
+

--- a/tests/run_travis_tests.sh
+++ b/tests/run_travis_tests.sh
@@ -36,3 +36,5 @@ julia --color=yes run_game_tests.jl
 
 julia --color=yes run_csp_tests.jl
 
+julia --color=yes run_logic_tests.jl
+

--- a/utils.jl
+++ b/utils.jl
@@ -17,7 +17,7 @@ export if_, Queue, FIFOQueue, Stack, PQueue, push!, pop!, extend!, delete!,
         weighted_sampler, weighted_sample_with_replacement,
         distance, distance2,
         RandomDeviceInstance,
-        isfunction;
+        isfunction, removeall;
 
 function if_(boolean_expression::Bool, ans1::Any, ans2::Any)
     if (boolean_expression)
@@ -450,6 +450,14 @@ function delete!(pq::PQueue, item::Any)
         end
     end
     return nothing;
+end
+
+function removeall(v::String, item)
+    return replace(v, item, "");
+end
+
+function removeall(v::AbstractVector, item)
+    return collect(x for x in v if (x != item));
 end
 
 """


### PR DESCRIPTION
@norvig This pull request covers symbols, variables, clauses, and algorithms in propositional logic (Chapters 7-9).

I wrote a lexicographical Expression parser that handles both infix and prefix operators in Julia to avoid relying on Julia's eval() and its corresponding lexicographical parser (Julia does not allow custom infix operator declarations such as "==>", "<=>", or "<=="). This means that "===\$==>", "*&%^", etc are evaluated as legal infix operators. 

This Expression parser is different from the aima-java lexicographical parser because this parser does not look ahead, though it still uses a expression tree.

Please note that HybridWumpusAgentProgram (percept and route planning in the Wumpus Environment) and fol_fc_ask are not fully implemented yet like in aima-python (logic.py).